### PR TITLE
Updated alliance members and added and one alliance

### DIFF
--- a/Alliances/airlines_alliances.json
+++ b/Alliances/airlines_alliances.json
@@ -4,13 +4,12 @@
     "airlines": [
       "A3",
       "AC",
+      "AI",
       "AV",
+      "BR",
       "CA",
       "CM",
       "ET",
-      "JJ",
-      "JP",
-      "KF",
       "LH",
       "LO",
       "LX",
@@ -20,62 +19,52 @@
       "OS",
       "OU",
       "OZ",
-      "PZ",
       "SA",
       "SK",
       "SN",
       "SQ",
-      "TA",
       "TG",
       "TK",
       "TP",
       "UA",
-      "US"
+      "ZH"
     ]
   },
   {
     "name": "oneworld",
     "airlines": [
-      "4M",
       "AA",
-      "AB",
+      "AS",
+      "AT",
+      "AY",
       "BA",
       "CX",
-      "AY",
-      "HG",
       "IB",
-      "JC",
       "JL",
-      "JO",
-      "KA",
-      "LA",
       "LP",
-      "MA",
-      "MN",
-      "MX",
-      "NU",
+      "MH",
       "QF",
+      "QR",
       "RJ",
       "S7",
-      "XL"
+      "UL"
     ]
   },
   {
     "name": "SkyTeam",
     "airlines": [
       "AF",
-      "AE",
       "AM",
       "AR",
       "AZ",
       "CI",
-      "CZ",
       "DL",
-      "FM",
+      "GA",
       "KE",
       "KL",
       "KQ",
       "ME",
+      "MF",
       "MU",
       "OK",
       "RO",
@@ -83,6 +72,16 @@
       "SV",
       "UX",
       "VN"
+    ]
+  },
+  {
+    "name": "Value Alliance",
+    "airlines": [
+      "5J",
+      "7C",
+      "DD",
+      "DG",
+      "TR"
     ]
   }
 ]


### PR DESCRIPTION
I updated the list of members for OneWorld, SkyTeam and Star Alliance. Add Value Alliance to the list. About Value Alliance, even though their website shows NookScoot (IATA code: XW) as one of the member, the airlines has gone defunct because of the pandemic (https://www.bangkokpost.com/business/1941572/nokscoot-goes-out-of-business).