### PR TITLE
Add APIbase — AI-ready flight API hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A curated list of awesome travel resources to help you build the next travel app
 | ADS-B Exchange | ADS-B Exchange API               | [Go!](https://www.adsbexchange.com/data/)                                                       |
 | Aviation Edge  | Global Database and API          | [Go!](https://aviation-edge.com/)                                                               |
 
+| APIbase | Unified flight API for AI agents: Amadeus + Sabre GDS wrapped in MCP. Search, price, status, routes. | [Go!](https://apibase.pro) |
 ### Flight data
 
 | API         | Description              | Link                                                          |


### PR DESCRIPTION
Hi! Adding [APIbase](https://apibase.pro) to the list. It's an MCP server that aggregates 56+ API tools (Amadeus, Sabre, Polymarket, crypto, weather) into a single endpoint for AI agents. Pay-per-call via x402 USDC micropayments.

GitHub: https://github.com/whiteknightonhorse/APIbase
Smithery: https://smithery.ai/servers/apibase-pro/api-hub (100/100 quality score)