### PR TITLE
Add TicketLens to Tours APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ A curated list of awesome travel resources to help you build the next travel app
 | API          | Description     | Link                                                           |
 | ------------ | --------------- | -------------------------------------------------------------- |
 | Getyourguide | City Guides API | [Go!](https://api.getyourguide.com/)                           |
+| TicketLens   | Destination experiences API for tours, attraction tickets, sports tickets, and activities | [Go!](https://api.ticketlens.com/v1/docs) |
 | Viator       | Tours API       | [Go!](https://docs.viator.com/partner-api/merchant/technical/) |
 
 ### Currencies


### PR DESCRIPTION
## What changed
- add a `TicketLens` row to the `### Tours` table
- point the link to the public TicketLens API docs

## Why
TicketLens provides a public destination-experiences API covering tours, attraction tickets, sports tickets, and activities, which matches the tours API section.

## Validation
- verified the table row formatting locally
- ran `git diff --check`
