### PR TITLE
Add Travel Safety / Country Risk section with Warnely

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ A curated list of awesome travel resources to help you build the next travel app
 | RoadGoat      | Content API for 4.3M cities, towns, countries, & neighborhoods | [Go!](https://www.roadgoat.com/business/cities-api)                |
 | Lonely Planet | Editorial content API                                          | [Go!](https://docs.dev.content-api.lonelyplanet.com/#introduction) |
 
+### Travel Safety / Country Risk
+
+| API     | Description                                                                                                                            | Link                                  |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| Warnely | Composite travel-safety scores for 180 countries (UK FCDO + US State + GPI + WGI + live incident wire). OpenAPI 3.1 spec, CC BY 4.0. | [Go!](https://warnely.com/developers) |
+
 ### Points of Interest (POIs) Content
 
 | API           | Description             | Link                                                                                                       |


### PR DESCRIPTION
Adds a new **Travel Safety / Country Risk** section to the README with Warnely as the first entry.

## What is Warnely?

A free composite travel-safety score for 180 countries, combining:

- UK FCDO travel advisories
- US State Department travel advisories
- Global Peace Index 2025
- World Bank Worldwide Governance Indicators
- A live news incident wire (Reuters, BBC, AP, AFP, USGS, GDACS, ReliefWeb)

## Why this section is missing today

The current sections cover destinations, POIs, hotels, flights, etc. None of them surface country-level risk data. A travel app builder doing pre-trip due diligence or duty-of-care work needs a separate primitive: safety. Adding the category as a placeholder for other safety APIs in future too.

## API details

- **Base URL**: `https://warnely.com/api/v1`
- **OpenAPI 3.1 spec**: https://warnely.com/openapi.json
- **Auth**: None
- **CORS**: Open
- **HTTPS**: Yes
- **License**: CC BY 4.0
- **Rate limit**: 100 req/min/IP

## Try it

```
curl https://warnely.com/api/v1/countries/TH
```

Returns the composite safety score, advisories, drug law tier, LGBTQ+ legal status, women's-safety rating, and quick facts for Thailand.