### PR TITLE
Add Superhighway API to Destinations/Cities/Countries Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ A curated list of awesome travel resources to help you build the next travel app
 | ------------- | -------------------------------------------------------------- | ------------------------------------------------------------------ |
 | RoadGoat      | Content API for 4.3M cities, towns, countries, & neighborhoods | [Go!](https://www.roadgoat.com/business/cities-api)                |
 | Lonely Planet | Editorial content API                                          | [Go!](https://docs.dev.content-api.lonelyplanet.com/#introduction) |
+| Superhighway  | Web search, news, scrape & deep-research API for AI travel agents. Research destinations, find attractions, pull advisories. MCP server, pay-per-call. | [Go!](https://superhighway.walls.sh) |
 
 ### Travel Safety / Country Risk
 


### PR DESCRIPTION
Adds **Superhighway** to the **Destinations/Cities/Countries Content** section.

Superhighway is a web search API for AI agents (search, news, scrape, deep research) — well suited for travel apps that research destinations, surface attractions, and pull live travel advisories. It exposes an MCP server (`npx -y superhighway-mcp`) and is pay-per-call.

For context, here's a worked example using it to build a Python travel-planning agent that researches a destination, finds attractions, pulls advisories, and generates a day-by-day itinerary: https://superhighway.walls.sh/guides/travel-planning-agent

Entry follows the existing table format. Thanks for maintaining this list!

🤖 Generated with [Claude Code](https://claude.com/claude-code)