### PR TITLE
Add a Cruises section with CruiseFeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ A curated list of awesome travel resources to help you build the next travel app
 | Sedna       | Sedna API. Сan give a description for free  | [Go!](https://www.sednasystem.io/our-services/sedna-api/)           |
 | NauSYS      | NauSYS API. Сan give a description for free | [Go!](https://www.nausys.com/api-data-stream/)                      |
 
+### Cruises
+
+| API        | Description                                                                                | Link                         |
+| ---------- | ------------------------------------------------------------------------------------------ | ---------------------------- |
+| CruiseFeed | Structured cruise itinerary, pricing and ship data across cruise lines, ports and regions  | [Go!](https://cruisefeed.io) |
+
 ### Events
 
 | API         | Description                             | Link                                                      |


### PR DESCRIPTION
Adds a new **Cruises** category to the list — the collection covers Flights, Hotels, Yacht rentals, etc. but has no cruise entry yet.

[CruiseFeed](https://cruisefeed.io) is a structured cruise-data API: normalized itineraries, pricing and ship specs across cruise lines, ports and regions, with CSV export and a Postman collection. Placed it right after Yacht rentals to keep the marine-travel entries together, matching the existing table format.