### PR TITLE
Add Sunshine Atlas to Other services

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ A curated list of awesome travel resources to help you build the next travel app
 | Weather & Forecast API | OpenWeather API                | [Go!](https://openweathermap.org/api)                 |
 | Beach Day              | Beach and beach-condition data for planning beach days | [Go!](https://beachdayapi.com) |
 | TransportAPI           | Transport data and development | [Go!](https://developer.transportapi.com/)            |
+| Sunshine Atlas | Monthly sunshine-hours & climate-normals data (temp, rainfall, sea temp) for 3,800+ destinations; open dataset (CC BY 4.0) + MCP server | [Go!](https://sunshineatlas.com/data/) |
 
 ## Star History
 


### PR DESCRIPTION
Hi — I'm the maker of Sunshine Atlas, a free, no-signup, ad-free interactive globe + open dataset (CC BY 4.0, DOI) ranking 3,833 flyable destinations by monthly sunshine hours and climate normals. Adding it under **Other services** because it's an open travel-planning data source + MCP server, like Beach Day / the sunrise-sunset API already listed. Happy to tweak the wording or placement — thanks for maintaining this list!