### PR TITLE
Add Stopover Planner to Flights

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A curated list of awesome travel resources to help you build the next travel app
 | ADS-B Exchange | ADS-B Exchange API               | [Go!](https://www.adsbexchange.com/data/)                                                       |
 | Aviation Edge  | Global Database and API          | [Go!](https://aviation-edge.com/)                                                               |
 | Ignav          | Live flight prices and booking links for AI agents and travel apps | [Go!](https://ignav.com)                                                                        |
+| Stopover Planner | Live Google Flights prices (GBP) with booking links: stopover itineraries, country-wide and explore-everywhere search | [Go!](https://rapidapi.com/stopover-labs-stopover-labs-default/api/stopover-planner) |
 
 | APIbase | Unified flight API for AI agents: Amadeus + Sabre GDS wrapped in MCP. Search, price, status, routes. | [Go!](https://apibase.pro) |
 ### Flight data


### PR DESCRIPTION
Adds Stopover Planner to the Flights section: live Google Flights prices in GBP with a booking link on every flight, and search types the list does not cover yet (multi-day stopover itineraries priced as one trip, country-wide sweeps, explore-everywhere). Free tier available via RapidAPI. Disclosure: I built this API.