### PR TITLE
Add: Wander China to Itinerary section

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ A curated list of awesome travel resources to help you build the next travel app
 | API    | Description            | Link                                    |
 | ------ | ---------------------- | --------------------------------------- |
 | TripIt | Travel Information API | [Go!](https://www.tripit.com/developer) |
+| Wander China | Free drag-and-drop China trip planner covering 31 cities with 1-day route recommendations | [Go!](https://ordinarymantrying.com/tools/wander-china/index.html) |
 
 ### Tours
 


### PR DESCRIPTION
Wander China is a free drag-and-drop China trip planner:
- Covers 31 Chinese cities
- Pre-built 1-day route recommendations for each city
- Interactive map with drag-and-drop reordering
- No login, no signup required
- Open source: https://github.com/daligao/wander-china

Link: https://ordinarymantrying.com/tools/wander-china/index.html