### PR TITLE
Add Visa / Entry requirements section

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ A curated list of awesome travel resources to help you build the next travel app
 | ------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
 | Warnely | Composite travel-safety scores for 180 countries (UK FCDO + US State + GPI + WGI + live incident wire). OpenAPI 3.1 spec, CC BY 4.0. | [Go!](https://warnely.com/developers) |
 
+### Visa / Entry requirements
+
+| API        | Description                                                                                                                                       | Link                                    |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| Orizn Visa | Visa requirements for 199 passports across 232 destinations, in 15 languages. Each response carries the date the pair was last verified. Free tier. | [Go!](https://visa.orizn.app/visa-api)  |
+
 ### Points of Interest (POIs) Content
 
 | API           | Description             | Link                                                                                                       |


### PR DESCRIPTION
The list covers flights, hotels, car and yacht rentals, cruises, eSIM, POIs and country risk — but there is no section for entry requirements, which is the one check that can stop a trip at the gate.

Adding the section with one entry: **Orizn Visa** — 199 passports × 232 destinations in 15 languages, free tier (50 req/month, no card). Two things make it worth listing next to Travel Safety rather than inside it: every response carries the date that specific passport/destination pair was last verified, and the dataset covers non-sovereign territories (Aruba, Curaçao, Cayman, Greenland, Guam, Gibraltar, Falklands, Saint-Barthélemy) that most visa datasets return as 404.

Happy to move it under an existing section instead if you'd rather not add one.