### PR TITLE
Add Pocket Drives to Car rentals

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ A curated list of awesome travel resources to help you build the next travel app
 | Skyscanner | Skyscanner Car Hire Live                             | [Go!](https://skyscanner.github.io/slate/)        |
 | Cartrawler | Car Booking Engine (signup for partnership required) | [Go!](https://www.cartrawler.com/ct/)             |
 | Allmyles   | Allmyles Flights API                                 | [Go!](https://allmyles.docs.apiary.io/)           |
+| Pocket Drives | P2P luxury, exotic, and EV rental search MCP. Independent hosts; booking finishes in the iOS app | [Go!](https://pocketdrives.ai/mcp) |
 
 ### Yacht rentals
 


### PR DESCRIPTION
Adds Pocket Drives to the Car rentals table.

- Listing repo: https://github.com/RevList/pocket-drives-mcp
- Remote Streamable HTTP (no auth): https://pocketdrives.ai/mcp
- Official registry: `ai.pocketdrives/pocket-drives`

Pocket Drives is a P2P luxury/exotic/EV rental marketplace. Independent hosts; PocketList Inc builds the platform. This server searches, quotes, and browses. Booking finishes in the iOS app.

Single new Car rentals row after Allmyles. Matches the existing table format and the list's recent AI-agent / MCP entries (Ignav, Superhighway, APIbase).