### PR TITLE
Add Wander Atlas — hourly crowd windows per attraction (free, no key)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ A curated list of awesome travel resources to help you build the next travel app
 | Foursquare    | Foursquare Places API   | [Go!](https://docs.foursquare.com/developer/reference/places-api-overview)                                 |
 | Sygic         | Sygic Travel API        | [Go!](http://docs.sygictravelapi.com/)                                                                     |
 | Famxplor      | Family Travel API       | [Go!](https://www.famxplor.com/api)                                                                        |
+| Wander Atlas | Hourly quiet and busy windows per attraction, weekday and weekend (no key) | [Go!](https://wanderatlasguides.com/api/) |
 
 ### Itinerary
 


### PR DESCRIPTION
Adds one row to **Points of Interest (POIs) Content**.

**What it is:** measured foot-traffic for 671 attractions across 20 countries — the hours each place reads quiet and busy, split weekday/weekend.

**Why it belongs here:** the POI APIs already listed give names, reviews and opening hours. None of them answer *when* a place is bearable — Google Places deliberately withholds popular times, so anyone building on it hits the same wall.

- Endpoint: https://wanderatlasguides.com/api/crowd.json
- Docs: https://wanderatlasguides.com/api/
- No key, no rate limit, CORS enabled, CC BY 4.0
- Each entry carries lat/lng, so it joins to whatever POI source you already use

Also listed in [public-apis](https://github.com/public-apis/public-apis) (Transportation).